### PR TITLE
Fix for boolean false query string values

### DIFF
--- a/src/qs.js
+++ b/src/qs.js
@@ -116,8 +116,12 @@ function QS(strUrl) {
     }
 
     // Boolean value:
-    if (objValue.match(/^true|false$/)) {
-      return Boolean(objValue);
+    if (objValue === 'true') {
+      return true;
+    }
+
+    if (objValue === 'false') {
+      return false;
     }
 
     // Undefined:

--- a/test/qs.js
+++ b/test/qs.js
@@ -4,6 +4,7 @@ describe("QS Library", function() {
     strURLMultipleQS = strURLNoQS + '?foo=bar&nir=baz',
     strURLWithSpecialCharactersQS = strURLNoQS + '?email=nire0510%40gmail.com',
     strURLMultipleAndValueOnlyQS = strURLNoQS + '?foo=bar&nir';
+    strURLWithFalseValue = strURLNoQS + '?flag=false';
 
   it("QS object", function() {
     expect(QS).toBeDefined();
@@ -32,6 +33,7 @@ describe("QS Library", function() {
     expect(QS(strURLMultipleQS).get('foo')).toEqual('bar');
     expect(QS(strURLMultipleQS).get('nir')).toEqual('baz');
     expect(QS(strURLWithSpecialCharactersQS).get('email')).toEqual('nire0510@gmail.com');
+    expect(QS(strURLWithFalseValue).get('flag')).toBeFalsy();
     // Check casting:
     expect(QS(strURLNoQS).set('num', 345).get('num')).toEqual(345);
     expect(QS(strURLNoQS).set('num', 345.56).get('num')).toEqual(345.56);


### PR DESCRIPTION
Currently, if your query string value is false, ie `?flag=false`, qs will return the true, because `Boolean("false")` returns true.
